### PR TITLE
feat: allow discounting GT with negative LT

### DIFF
--- a/cmd/eigentrust/cmd/basiccompute.go
+++ b/cmd/eigentrust/cmd/basiccompute.go
@@ -124,8 +124,6 @@ func loadInlineLocalTrustCsv(filename string, ref *basic.LocalTrustRef) error {
 		switch {
 		case err != nil:
 			return inputWrapf(err, 2, "invalid trust value=%#v", fields[2])
-		case value < 0:
-			return inputErrorf(2, "negative value=%#v", value)
 		}
 		i, j := int(from), int(to)
 		inline.Entries = append(inline.Entries,

--- a/pkg/basic/eigentrust_test.go
+++ b/pkg/basic/eigentrust_test.go
@@ -1,0 +1,77 @@
+package basic
+
+import (
+	"testing"
+
+	"github.com/magiconair/properties/assert"
+	"k3l.io/go-eigentrust/pkg/sparse"
+)
+
+func TestDiscountTrustVector(t *testing.T) {
+	type args struct {
+		t         *sparse.Vector
+		discounts *sparse.Matrix
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *sparse.Vector
+	}{
+		{
+			"test1",
+			args{
+				t: &sparse.Vector{
+					Dim: 5,
+					Entries: []sparse.Entry{
+						{0, 0.25},
+						{2, 0.5},
+						{3, 0.25},
+					},
+				},
+				discounts: &sparse.Matrix{
+					CSMatrix: sparse.CSMatrix{
+						MajorDim: 5,
+						MinorDim: 5,
+						Entries: [][]sparse.Entry{
+							// 0 - no distrust
+							{},
+							// 1 - doesn't matter because of zero trust
+							{
+								{2, 0.5},
+								{3, 0.5},
+							},
+							// 2 - scaled by 0.5 and applied
+							{
+								{0, 0.25},
+								{4, 0.75},
+							},
+							// 3 - scaled by 0.25 and applied
+							{
+								{2, 0.5},
+								{4, 0.5},
+							},
+							// 4 - no distrust, also zero global trust
+							{},
+						},
+					},
+				},
+			},
+			&sparse.Vector{
+				Dim: 5,
+				Entries: []sparse.Entry{
+					// {index, original - distrust*gt}
+					{0, 0.25 - 0.25*0.5 /* peer 2 */},
+					{2, 0.5 - 0.5*0.25 /* peer 3 */},
+					{3, 0.25},
+					{4, 0 - 0.75*0.5 /* peer 2 */ - 0.5*0.25 /* peer 3 */},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			DiscountTrustVector(tt.args.t, tt.args.discounts)
+			assert.Equal(t, tt.args.t, tt.expected)
+		})
+	}
+}

--- a/pkg/basic/localtrust_test.go
+++ b/pkg/basic/localtrust_test.go
@@ -1,0 +1,79 @@
+package basic
+
+import (
+	"reflect"
+	"testing"
+
+	"k3l.io/go-eigentrust/pkg/sparse"
+)
+
+func TestExtractDistrust(t *testing.T) {
+	type args struct {
+		localTrust *sparse.Matrix
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantTrust    *sparse.Matrix
+		wantDistrust *sparse.Matrix
+		wantErr      bool
+	}{
+		{
+			name: "test1",
+			args: args{
+				&sparse.Matrix{
+					CSMatrix: sparse.CSMatrix{
+						MajorDim: 3,
+						MinorDim: 3,
+						Entries: [][]sparse.Entry{
+							/* 0 */ {{0, 100}, {1, -50}, {2, -50}},
+							/* 1 */ nil,
+							/* 2 */ {{0, -100}},
+						},
+					},
+				},
+			},
+			wantTrust: &sparse.Matrix{
+				CSMatrix: sparse.CSMatrix{
+					MajorDim: 3,
+					MinorDim: 3,
+					Entries: [][]sparse.Entry{
+						/* 0 */ {{0, 100}},
+						/* 1 */ nil,
+						/* 2 */ nil,
+					},
+				},
+			},
+			wantDistrust: &sparse.Matrix{
+				CSMatrix: sparse.CSMatrix{
+					MajorDim: 3,
+					MinorDim: 3,
+					Entries: [][]sparse.Entry{
+						/* 0 */ {{1, 50}, {2, 50}},
+						/* 1 */ nil,
+						/* 2 */ {{0, 100}},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractDistrust(tt.args.localTrust)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExtractDistrust() error = %v, wantErr %v", err,
+					tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(tt.args.localTrust, tt.wantTrust) {
+				t.Errorf("ExtractDistrust() got trust = %v, want %v",
+					tt.args.localTrust, tt.wantTrust)
+			}
+			if !reflect.DeepEqual(got, tt.wantDistrust) {
+				t.Errorf("ExtractDistrust() got distrust = %v, want %v",
+					got, tt.wantDistrust)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allow peers to express, with negative local trust values, lower opinions than "I don't know/care" about other peers.  Then after the EigenTrust run, reflect the negative opinions held by each peer, normalized and weighted by the peer's own trust score.  (If the peer has zero trust score, the peer's distrust opinions scale to zero, i.e. the distrust opinions do not matter.)