### PR TITLE
feat: update the go version to 1.21 from 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.21
 
 WORKDIR /app
 


### PR DESCRIPTION
docker build 
```
 => CACHED [4/6] RUN go mod download                                                                                                                                                                                                                                                              0.0s
 => [5/6] COPY . .                                                                                                                                                                                                                                                                                0.1s
 => ERROR [6/6] RUN go build -o /app/build/main cmd/eigentrust/main.go                                                                                                                                                                                                                            7.3s
------                                                                                                                                                                                                                                                                                                 
 > [6/6] RUN go build -o /app/build/main cmd/eigentrust/main.go:                                                                                                                                                                                                                                       
3.401 # k3l.io/go-eigentrust/pkg/sparse                                                                                                                                                                                                                                                                
3.401 pkg/sparse/matrix.go:159:16: undefined: max
3.401 pkg/sparse/matrix.go:160:16: undefined: max
3.401 pkg/sparse/vector.go:75:48: undefined: max
3.401 pkg/sparse/vector.go:112:48: undefined: max
3.401 note: module requires Go 1.21
------
Dockerfile:11
--------------------
   9 |     # COPY All things inside the project and build
  10 |     COPY . .
  11 | >>> RUN go build -o /app/build/main cmd/eigentrust/main.go
  12 |     
  13 |     EXPOSE 80
--------------------
ERROR: failed to solve: process "/bin/sh -c go build -o /app/build/main cmd/eigentrust/main.go" did not complete successfully: exit code: 1
```