### PR TITLE
Docker compose to startup go-eigentrust with file uri support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,10 @@ services:
       - "8081:80"
     command: ["/app/build/main", "serve"]
 
-  go-eigentrust-9091:
+  go-eigentrust-9081:
     build: .
     image: go-eigentrust:latest
-    container_name: go-eigentrust-9091
+    container_name: go-eigentrust-9081
     ports:
       - "9081:80"
     command: ["/app/build/main", "serve"]

--- a/fileuri-docker-compose.yml
+++ b/fileuri-docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  go-eigentrust-8081:
+    build: 
+      dockerfile: fileuri.Dockerfile
+    image: go-eigentrust:latest
+    container_name: go-eigentrust-8081
+    volumes:
+      - ${GO_EIGENTRUST_BIND_SRC}:${GO_EIGENTRUST_BIND_TARGET}:z
+    ports:
+      - "8081:80"
+
+  go-eigentrust-9081:
+    build: 
+      dockerfile: fileuri.Dockerfile
+    image: go-eigentrust:latest
+    container_name: go-eigentrust-9081
+    volumes:
+      - ${GO_EIGENTRUST_BIND_SRC}:${GO_EIGENTRUST_BIND_TARGET}:z
+    ports:
+      - "9081:80"

--- a/fileuri.Dockerfile
+++ b/fileuri.Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.21
+
+WORKDIR /app
+
+# COPY go.mod, go.sum and download the dependencies
+COPY go.* ./
+RUN go mod download
+
+# COPY All things inside the project and build
+COPY . .
+RUN go build -o /app/build/main cmd/eigentrust/main.go
+
+EXPOSE 80
+CMD [ "/app/build/main", "serve", "-F" ]


### PR DESCRIPTION
On some linux hosts, we need to startup go-eigentrust with File Uri support because memory mapping matrices fails with the Rest API.  This PR provides an additional docker-compose file that can be used for such hosts.