### PR TITLE
fix: docker instance does not restart automatically after crash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.8'
 
 services:
   go-eigentrust-8081:
+    restart: unless-stopped
     build: .
     image: go-eigentrust:latest
     container_name: go-eigentrust-8081
@@ -10,6 +11,7 @@ services:
     command: ["/app/build/main", "serve"]
 
   go-eigentrust-9081:
+    restart: unless-stopped
     build: .
     image: go-eigentrust:latest
     container_name: go-eigentrust-9081


### PR DESCRIPTION
docker-compose is missing the restart directive